### PR TITLE
EXTENDOPEN-12 : Use the URL provided by the ExtendableRessourceService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 	  	<dependency>
 	    	<groupId>fr.paris.lutece.plugins</groupId>
 	    	<artifactId>plugin-extend</artifactId>
-	    	<version>[1.0.1-SNAPSHOT,)</version>
+               <version>[1.3.0-SNAPSHOT,)</version>
 	    	<type>lutece-plugin</type>
 	  	</dependency>
 	</dependencies>

--- a/src/java/fr/paris/lutece/plugins/extend/modules/opengraph/web/component/OpengraphResourceExtenderComponent.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/opengraph/web/component/OpengraphResourceExtenderComponent.java
@@ -389,19 +389,26 @@ public class OpengraphResourceExtenderComponent extends AbstractResourceExtender
         ogtags.setImageUrl( strImageUrl );
 
         // url
-        StringBuffer sbUrl = request.getRequestURL(  );
-
-        if ( sbUrl != null )
+        String sUrl = _resourceExtenderService.getExtendableResourceUrl( extendableResource.getIdExtendableResource( ), extendableResource.getExtendableResourceType( ) );
+        if ( sUrl == null )
         {
-            String strQuery = request.getQueryString(  );
+            StringBuffer sbUrl = request.getRequestURL(  );
 
-            if ( StringUtils.isNotBlank( strQuery ) )
+            if ( sbUrl != null )
             {
-                sbUrl.append( CONSTANT_QUESTION_MARK );
-                sbUrl.append( strQuery );
-            }
+                String strQuery = request.getQueryString(  );
 
-            ogtags.setUrl( sbUrl.toString(  ) );
+                if ( StringUtils.isNotBlank( strQuery ) )
+                {
+                    sbUrl.append( CONSTANT_QUESTION_MARK );
+                    sbUrl.append( strQuery );
+                }
+
+                ogtags.setUrl( sbUrl.toString(  ) );
+            }
+        } else
+        {
+            ogtags.setUrl( AppPathService.getProdUrl( request ) + sUrl );
         }
 
         ogtags.setTitle( extendableResource.getExtendableResourceName(  ) );


### PR DESCRIPTION
in the meta tags

Use a new API provided by plugin-extend to access the URL.

This PR depends on PR https://github.com/lutece-platform/lutece-extends-plugin-extend/pull/1
